### PR TITLE
Add `add_dotnet_test_project`

### DIFF
--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -120,6 +120,44 @@ function(add_dotnet_project _TARGET_NAME)
   )
 endfunction()
 
+function(add_dotnet_test_project _TARGET_NAME)
+  # TODO: (sh) It seems the test project gets build twice with different output directories
+  # e.g.: the same output files are contained in "build/<package>/<target>/net6.0/" and "build/<package>/<target>/net6.0/linux-x64"
+  # But this seems to be the case with other projects as well (package rcldotnet and targets rcldotnet_assemblies and test_messages).
+  # So maybe this is how it should be, but why?
+
+  cmake_parse_arguments(_add_dotnet_test_project
+    ""
+    ""
+    "PROJ;INCLUDE_DLLS"
+    ${ARGN}
+  )
+
+  csharp_add_existing_project(${_TARGET_NAME}
+    EXECUTABLE
+    PROJ
+    ${_add_dotnet_test_project_PROJ}
+    ${_add_dotnet_test_project_UNPARSED_ARGUMENTS}
+    INCLUDE_DLLS
+    ${_add_dotnet_test_project_INCLUDE_DLLS}
+  )
+
+  if(CSBUILD_PROJECT_DIR)
+    set(CURRENT_TARGET_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/${CSBUILD_PROJECT_DIR}")
+  else()
+    set(CURRENT_TARGET_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+  endif()
+
+  get_filename_component(_add_dotnet_test_project_PROJ_ABSOLUTE ${_add_dotnet_test_project_PROJ} ABSOLUTE)
+
+  ament_add_test(
+    ${_TARGET_NAME}
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    WORKING_DIRECTORY ${CURRENT_TARGET_BINARY_DIR}/${_TARGET_NAME}
+    COMMAND dotnet test ${_add_dotnet_test_project_PROJ_ABSOLUTE}
+  )
+endfunction()
+
 function(install_dotnet _TARGET_NAME)
     get_target_property(_target_executable ${_TARGET_NAME} EXECUTABLE)
     get_target_property(_target_path ${_TARGET_NAME} OUTPUT_PATH)

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -102,8 +102,25 @@ function(add_dotnet_test _TARGET_NAME)
 
 endfunction()
 
-function(add_dotnet_project _TARGET_NAME)
-  cmake_parse_arguments(_add_dotnet_project
+function(add_dotnet_library_project _TARGET_NAME)
+  cmake_parse_arguments(_add_dotnet_library_project
+    ""
+    ""
+    "PROJ;INCLUDE_DLLS"
+    ${ARGN}
+  )
+
+  csharp_add_existing_project(${_TARGET_NAME}
+    PROJ
+    ${_add_dotnet_library_project_PROJ}
+    ${_add_dotnet_library_project_UNPARSED_ARGUMENTS}
+    INCLUDE_DLLS
+    ${_add_dotnet_library_project_INCLUDE_DLLS}
+  )
+endfunction()
+
+function(add_dotnet_executable_project _TARGET_NAME)
+  cmake_parse_arguments(_add_dotnet_executable_project
     ""
     ""
     "PROJ;INCLUDE_DLLS"
@@ -113,10 +130,10 @@ function(add_dotnet_project _TARGET_NAME)
   csharp_add_existing_project(${_TARGET_NAME}
     EXECUTABLE
     PROJ
-    ${_add_dotnet_project_PROJ}
-    ${_add_dotnet_project_UNPARSED_ARGUMENTS}
+    ${_add_dotnet_executable_project_PROJ}
+    ${_add_dotnet_executable_project_UNPARSED_ARGUMENTS}
     INCLUDE_DLLS
-    ${_add_dotnet_project_INCLUDE_DLLS}
+    ${_add_dotnet_executable_project_INCLUDE_DLLS}
   )
 endfunction()
 

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -175,8 +175,6 @@ function(add_dotnet_test_project _TARGET_NAME)
   )
 endfunction()
 
-# TODO: Add an argument to name the entry point different than the target.
-#       Renaming the target in the *.csproj does cause issues with ASP.NET
 function(install_dotnet _TARGET_NAME)
     get_target_property(_target_executable ${_TARGET_NAME} EXECUTABLE)
     get_target_property(_target_path ${_TARGET_NAME} OUTPUT_PATH)
@@ -188,7 +186,7 @@ function(install_dotnet _TARGET_NAME)
     else()
       cmake_parse_arguments(_install_dotnet
         "CD_TO_EXECUTABLE"
-        "DESTINATION"
+        "DESTINATION;ENTRY_POINT_NAME"
         ""
         ${ARGN})
       if (_install_dotnet_DESTINATION)
@@ -200,23 +198,29 @@ function(install_dotnet _TARGET_NAME)
     install(DIRECTORY ${_target_path}/ DESTINATION ${_DESTINATION})
 
     if(_target_executable)
+      if (_install_dotnet_ENTRY_POINT_NAME)
+        set(_ENTRY_POINT_NAME ${_install_dotnet_ENTRY_POINT_NAME})
+      else()
+        # default to _TARGET_NAME
+        set(_ENTRY_POINT_NAME ${_TARGET_NAME})
+      endif()
       set(DOTNET_DLL_PATH ${_target_name})
       if(WIN32)
         if (_install_dotnet_CD_TO_EXECUTABLE)
-          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.windows.in lib/${_ENTRY_POINT_NAME}.bat @ONLY)
         else()
-          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.windows.in lib/${_ENTRY_POINT_NAME}.bat @ONLY)
         endif()
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_TARGET_NAME}.bat
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_ENTRY_POINT_NAME}.bat
           DESTINATION
           lib/${PROJECT_NAME})
       else()
         if (_install_dotnet_CD_TO_EXECUTABLE)
-          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.unix.in lib/${_TARGET_NAME} @ONLY)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.unix.in lib/${_ENTRY_POINT_NAME} @ONLY)
         else()
-          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.unix.in lib/${_TARGET_NAME} @ONLY)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.unix.in lib/${_ENTRY_POINT_NAME} @ONLY)
         endif()
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_TARGET_NAME}
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_ENTRY_POINT_NAME}
           DESTINATION
           lib/${PROJECT_NAME}
           PERMISSIONS

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -175,6 +175,8 @@ function(add_dotnet_test_project _TARGET_NAME)
   )
 endfunction()
 
+# TODO: Add an argument to name the entry point different than the target.
+#       Renaming the target in the *.csproj does cause issues with ASP.NET
 function(install_dotnet _TARGET_NAME)
     get_target_property(_target_executable ${_TARGET_NAME} EXECUTABLE)
     get_target_property(_target_path ${_TARGET_NAME} OUTPUT_PATH)
@@ -185,7 +187,7 @@ function(install_dotnet _TARGET_NAME)
       set (_DESTINATION ${ARGV1})
     else()
       cmake_parse_arguments(_install_dotnet
-        ""
+        "CD_TO_EXECUTABLE"
         "DESTINATION"
         ""
         ${ARGN})
@@ -200,12 +202,20 @@ function(install_dotnet _TARGET_NAME)
     if(_target_executable)
       set(DOTNET_DLL_PATH ${_target_name})
       if(WIN32)
-        configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+        if (_install_dotnet_CD_TO_EXECUTABLE)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+        else()
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+        endif()
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_TARGET_NAME}.bat
           DESTINATION
           lib/${PROJECT_NAME})
       else()
-        configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.unix.in lib/${_TARGET_NAME} @ONLY)
+        if (_install_dotnet_CD_TO_EXECUTABLE)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.unix.in lib/${_TARGET_NAME} @ONLY)
+        else()
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.unix.in lib/${_TARGET_NAME} @ONLY)
+        endif()
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_TARGET_NAME}
           DESTINATION
           lib/${PROJECT_NAME}

--- a/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
+++ b/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
@@ -228,7 +228,7 @@ function(csharp_add_existing_project name)
 
     set(_csharp_add_existing_project_PROPS_PATH ${_csharp_add_existing_project_PROJ_PATH_ABSOLUTE}/obj/CMake.g.props)
 
-    set(CSHARP_BUILDER_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+    set(CSHARP_BUILDER_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${name}/${CMAKE_BUILD_TYPE})
     file(TO_NATIVE_PATH ${CSHARP_BUILDER_OUTPUT_PATH} CSHARP_BUILDER_OUTPUT_PATH_NATIVE)
 
     # TODO: add to add_custom_target to avoid writing every time

--- a/cmake/Modules/dotnet/entry_point_with_cd.unix.in
+++ b/cmake/Modules/dotnet/entry_point_with_cd.unix.in
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P)"
+
+cd ${SCRIPTDIR}/dotnet/
+dotnet ${SCRIPTDIR}/dotnet/@DOTNET_DLL_PATH@ "$@"

--- a/cmake/Modules/dotnet/entry_point_with_cd.windows.in
+++ b/cmake/Modules/dotnet/entry_point_with_cd.windows.in
@@ -1,0 +1,2 @@
+cd /D %~f0\dotnet\
+dotnet %~f0\dotnet\@DOTNET_DLL_PATH@ %*


### PR DESCRIPTION
Used to add test `*.csproj` files without generating them from cmake.

# New variants of `add_dotnet_*`

The base branch `feature-include-csproj` and this branch adds the posibility to use your own `*.csproj` files instead of generating one with cmake.
This makes it easier to use advanced `*.csproj` features needed for ASP.NET as the developer can directly manipulate the `.csproj` file.

This is how the new commands corespond to the existing ones:
```
add_dotnet_executable -> add_dotnet_executable_project
add_dotnet_library -> add_dotnet_library_project
add_dotnet_test -> add_dotnet_test_project
```
Example:
```cmake
...
set(_assemblies_dep_dlls
    ${rcldotnet_common_ASSEMBLIES_DLL}
    ${rcldotnet_ASSEMBLIES_DLL}
    ${std_msgs_ASSEMBLIES_DLL}
    ${std_srvs_ASSEMBLIES_DLL}
)

add_dotnet_executable_project(RosBlazorExample
  PROJ
  src/RosBlazorExample/RosBlazorExample.csproj
  INCLUDE_DLLS
  ${_assemblies_dep_dlls}
)
...
```

RosBlazorExample.csproj needs to import a generated file for this to work:
```xml
  <Import Project="obj/CMake.g.props"/>
```

# New options for `install_dotnet()`

## CD_TO_EXECUTABLE

This option changes the entry point script to change the working directory to the directory of the dotnet executable dll. his is usefull for ASP.NET projets as they expect the resources relative to `pwd`.

## ENTRY_POINT_NAME

This option changes the name of the entry point script. This is the name which `ros2 run` uses to start the executable.

Example:
```cmake
...
add_dotnet_executable_project(RosBlazorExample
  PROJ
  src/RosBlazorExample/RosBlazorExample.csproj
  INCLUDE_DLLS
  ${_assemblies_dep_dlls}
)

install_dotnet(RosBlazorExample
  CD_TO_EXECUTABLE
  ENTRY_POINT_NAME
  ros_blazor_example
  DESTINATION
  lib/${PROJECT_NAME}/dotnet
)
...
```
