### PR TITLE
Add support for building your own *.csproj files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@ Parts of this project based on code by Illumina.
 For more info:
 
 https://github.com/Illumina/interop
+
+## `.csproj` support
+It is possible to include eg. a C# project `.csproj` file with the `add_dotnet_project` function.
+This `.csproj` file must include a line
+
+```xml
+<Import Project="obj/CMake.g.props"/>
+```
+
+as this is where CMake generates references to other ROS 2 packages in, as well as the output path and the assembly name.

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -107,6 +107,24 @@ function(add_dotnet_test _TARGET_NAME)
 
 endfunction()
 
+function(add_dotnet_project _TARGET_NAME)
+  cmake_parse_arguments(_add_dotnet_project
+    ""
+    ""
+    "PROJ;INCLUDE_DLLS"
+    ${ARGN}
+  )
+
+  csharp_add_existing_project(${_TARGET_NAME}
+    EXECUTABLE
+    PROJ
+    ${_add_dotnet_project_PROJ}
+    ${_add_dotnet_project_UNPARSED_ARGUMENTS}
+    INCLUDE_DLLS
+    ${_add_dotnet_project_INCLUDE_DLLS}
+  )
+endfunction()
+
 function(install_dotnet _TARGET_NAME)
     get_target_property(_target_executable ${_TARGET_NAME} EXECUTABLE)
     get_target_property(_target_path ${_TARGET_NAME} OUTPUT_PATH)

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -118,7 +118,7 @@ function(install_dotnet _TARGET_NAME)
     else()
       cmake_parse_arguments(_install_dotnet
         "CD_TO_EXECUTABLE"
-        "DESTINATION"
+        "DESTINATION;ENTRY_POINT_NAME"
         ""
         ${ARGN})
       if (_install_dotnet_DESTINATION)
@@ -130,23 +130,29 @@ function(install_dotnet _TARGET_NAME)
     install(DIRECTORY ${_target_path}/ DESTINATION ${_DESTINATION})
 
     if(_target_executable)
+      if (_install_dotnet_ENTRY_POINT_NAME)
+        set(_ENTRY_POINT_NAME ${_install_dotnet_ENTRY_POINT_NAME})
+      else()
+        # default to _TARGET_NAME
+        set(_ENTRY_POINT_NAME ${_TARGET_NAME})
+      endif()
       set(DOTNET_DLL_PATH ${_target_name})
       if(WIN32)
         if (_install_dotnet_CD_TO_EXECUTABLE)
-          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.windows.in lib/${_ENTRY_POINT_NAME}.bat @ONLY)
         else()
-          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.windows.in lib/${_ENTRY_POINT_NAME}.bat @ONLY)
         endif()
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_TARGET_NAME}.bat
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_ENTRY_POINT_NAME}.bat
           DESTINATION
           lib/${PROJECT_NAME})
       else()
         if (_install_dotnet_CD_TO_EXECUTABLE)
-          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.unix.in lib/${_TARGET_NAME} @ONLY)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.unix.in lib/${_ENTRY_POINT_NAME} @ONLY)
         else()
-          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.unix.in lib/${_TARGET_NAME} @ONLY)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.unix.in lib/${_ENTRY_POINT_NAME} @ONLY)
         endif()
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_TARGET_NAME}
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_ENTRY_POINT_NAME}
           DESTINATION
           lib/${PROJECT_NAME}
           PERMISSIONS

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -117,7 +117,7 @@ function(install_dotnet _TARGET_NAME)
       set (_DESTINATION ${ARGV1})
     else()
       cmake_parse_arguments(_install_dotnet
-        ""
+        "CD_TO_EXECUTABLE"
         "DESTINATION"
         ""
         ${ARGN})
@@ -132,12 +132,20 @@ function(install_dotnet _TARGET_NAME)
     if(_target_executable)
       set(DOTNET_DLL_PATH ${_target_name})
       if(WIN32)
-        configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+        if (_install_dotnet_CD_TO_EXECUTABLE)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+        else()
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+        endif()
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_TARGET_NAME}.bat
           DESTINATION
           lib/${PROJECT_NAME})
       else()
-        configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.unix.in lib/${_TARGET_NAME} @ONLY)
+        if (_install_dotnet_CD_TO_EXECUTABLE)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.unix.in lib/${_TARGET_NAME} @ONLY)
+        else()
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.unix.in lib/${_TARGET_NAME} @ONLY)
+        endif()
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_TARGET_NAME}
           DESTINATION
           lib/${PROJECT_NAME}

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -61,12 +61,17 @@ endfunction()
 function(add_dotnet_test _TARGET_NAME)
   cmake_parse_arguments(_add_dotnet_test
     ""
-    ""
+    "TARGET_FRAMEWORK"
     "SOURCES;INCLUDE_DLLS;INCLUDE_NUPKGS;INCLUDE_REFERENCES"
     ${ARGN}
   )
 
-  set(CSHARP_TARGET_FRAMEWORK "netcoreapp2.0")
+  if(_add_dotnet_test_TARGET_FRAMEWORK)
+    set(CSHARP_TARGET_FRAMEWORK ${_add_dotnet_test_TARGET_FRAMEWORK})
+  else()
+    set(CSHARP_TARGET_FRAMEWORK "netcoreapp2.0")
+  endif()
+
   set(XUNIT_INCLUDE_REFERENCES
     "Microsoft.NET.Test.Sdk=15.9.0"
     "xunit=2.4.1"

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -107,8 +107,25 @@ function(add_dotnet_test _TARGET_NAME)
 
 endfunction()
 
-function(add_dotnet_project _TARGET_NAME)
-  cmake_parse_arguments(_add_dotnet_project
+function(add_dotnet_library_project _TARGET_NAME)
+  cmake_parse_arguments(_add_dotnet_library_project
+    ""
+    ""
+    "PROJ;INCLUDE_DLLS"
+    ${ARGN}
+  )
+
+  csharp_add_existing_project(${_TARGET_NAME}
+    PROJ
+    ${_add_dotnet_library_project_PROJ}
+    ${_add_dotnet_library_project_UNPARSED_ARGUMENTS}
+    INCLUDE_DLLS
+    ${_add_dotnet_library_project_INCLUDE_DLLS}
+  )
+endfunction()
+
+function(add_dotnet_executable_project _TARGET_NAME)
+  cmake_parse_arguments(_add_dotnet_executable_project
     ""
     ""
     "PROJ;INCLUDE_DLLS"
@@ -118,10 +135,10 @@ function(add_dotnet_project _TARGET_NAME)
   csharp_add_existing_project(${_TARGET_NAME}
     EXECUTABLE
     PROJ
-    ${_add_dotnet_project_PROJ}
-    ${_add_dotnet_project_UNPARSED_ARGUMENTS}
+    ${_add_dotnet_executable_project_PROJ}
+    ${_add_dotnet_executable_project_UNPARSED_ARGUMENTS}
     INCLUDE_DLLS
-    ${_add_dotnet_project_INCLUDE_DLLS}
+    ${_add_dotnet_executable_project_INCLUDE_DLLS}
   )
 endfunction()
 

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -125,6 +125,44 @@ function(add_dotnet_project _TARGET_NAME)
   )
 endfunction()
 
+function(add_dotnet_test_project _TARGET_NAME)
+  # TODO: (sh) It seems the test project gets build twice with different output directories
+  # e.g.: the same output files are contained in "build/<package>/<target>/net6.0/" and "build/<package>/<target>/net6.0/linux-x64"
+  # But this seems to be the case with other projects as well (package rcldotnet and targets rcldotnet_assemblies and test_messages).
+  # So maybe this is how it should be, but why?
+
+  cmake_parse_arguments(_add_dotnet_test_project
+    ""
+    ""
+    "PROJ;INCLUDE_DLLS"
+    ${ARGN}
+  )
+
+  csharp_add_existing_project(${_TARGET_NAME}
+    EXECUTABLE
+    PROJ
+    ${_add_dotnet_test_project_PROJ}
+    ${_add_dotnet_test_project_UNPARSED_ARGUMENTS}
+    INCLUDE_DLLS
+    ${_add_dotnet_test_project_INCLUDE_DLLS}
+  )
+
+  if(CSBUILD_PROJECT_DIR)
+    set(CURRENT_TARGET_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/${CSBUILD_PROJECT_DIR}")
+  else()
+    set(CURRENT_TARGET_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+  endif()
+
+  get_filename_component(_add_dotnet_test_project_PROJ_ABSOLUTE ${_add_dotnet_test_project_PROJ} ABSOLUTE)
+
+  ament_add_test(
+    ${_TARGET_NAME}
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    WORKING_DIRECTORY ${CURRENT_TARGET_BINARY_DIR}/${_TARGET_NAME}
+    COMMAND dotnet test ${_add_dotnet_test_project_PROJ_ABSOLUTE}
+  )
+endfunction()
+
 function(install_dotnet _TARGET_NAME)
     get_target_property(_target_executable ${_TARGET_NAME} EXECUTABLE)
     get_target_property(_target_path ${_TARGET_NAME} OUTPUT_PATH)

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -69,7 +69,7 @@ function(add_dotnet_test _TARGET_NAME)
   if(_add_dotnet_test_TARGET_FRAMEWORK)
     set(CSHARP_TARGET_FRAMEWORK ${_add_dotnet_test_TARGET_FRAMEWORK})
   else()
-    set(CSHARP_TARGET_FRAMEWORK "netcoreapp2.0")
+    set(CSHARP_TARGET_FRAMEWORK "net6.0")
   endif()
 
   set(XUNIT_INCLUDE_REFERENCES

--- a/cmake/Modules/dotnet/CMake.g.props.in
+++ b/cmake/Modules/dotnet/CMake.g.props.in
@@ -1,0 +1,8 @@
+<Project>
+  <ItemGroup>
+@CSHARP_BUILDER_INCLUDE_DLLS_STR@  </ItemGroup>
+  <PropertyGroup>
+    <OutputPath>@CSHARP_BUILDER_OUTPUT_PATH_NATIVE@</OutputPath>
+    <AssemblyName>@_TARGET_NAME@</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
+++ b/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
@@ -210,7 +210,7 @@ function(csharp_add_existing_project name)
 
     foreach(it ${_csharp_add_existing_project_INCLUDE_DLLS})
         file(TO_NATIVE_PATH ${it} nit)
-        list(APPEND refs "    <Reference Include=\"${nit}\";/>\n")
+        list(APPEND refs "    <Reference Include=\"${nit}\"/>\n")
     endforeach()
 
     list(LENGTH refs REFERENCE_COUNT)
@@ -232,21 +232,9 @@ function(csharp_add_existing_project name)
     file(TO_NATIVE_PATH ${CSHARP_BUILDER_OUTPUT_PATH} CSHARP_BUILDER_OUTPUT_PATH_NATIVE)
 
     # TODO: add to add_custom_target to avoid writing every time
-    file(WRITE ${_csharp_add_existing_project_PROPS_PATH}
-        "<Project>\n"
-        "  <ItemGroup>\n"
-        ${refs_concat}
-        "  </ItemGroup>\n"
-        "  <PropertyGroup>\n"
-        "    <OutputPath>"
-        ${CSHARP_BUILDER_OUTPUT_PATH_NATIVE}
-        "</OutputPath>\n"
-        "<AssemblyName>"
-        ${_TARGET_NAME}
-        "</AssemblyName>\n"
-        "  </PropertyGroup>"
-        "</Project>\n"
-    )
+    string (REPLACE ";" "" CSHARP_BUILDER_INCLUDE_DLLS_STR "${refs_concat}")
+    set(CSHARP_BUILDER_INCLUDE_DLLS ${refs_concat})
+    configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/CMake.g.props.in ${_csharp_add_existing_project_PROPS_PATH} @ONLY)
 
     if(${_csharp_add_existing_project_EXECUTABLE} AND NOT DOTNET_CORE_FOUND)
         set(ext "exe")

--- a/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
+++ b/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
@@ -228,7 +228,7 @@ function(csharp_add_existing_project name)
 
     set(_csharp_add_existing_project_PROPS_PATH ${_csharp_add_existing_project_PROJ_PATH_ABSOLUTE}/obj/CMake.g.props)
 
-    set(CSHARP_BUILDER_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+    set(CSHARP_BUILDER_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${name}/${CMAKE_BUILD_TYPE})
     file(TO_NATIVE_PATH ${CSHARP_BUILDER_OUTPUT_PATH} CSHARP_BUILDER_OUTPUT_PATH_NATIVE)
 
     # TODO: add to add_custom_target to avoid writing every time

--- a/cmake/Modules/dotnet/entry_point.unix.in
+++ b/cmake/Modules/dotnet/entry_point.unix.in
@@ -2,4 +2,4 @@
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P)"
 
-dotnet ${SCRIPTDIR}/dotnet/@DOTNET_DLL_PATH@
+dotnet ${SCRIPTDIR}/dotnet/@DOTNET_DLL_PATH@ "$@"

--- a/cmake/Modules/dotnet/entry_point.windows.in
+++ b/cmake/Modules/dotnet/entry_point.windows.in
@@ -1,1 +1,1 @@
-dotnet %~f0\dotnet\@DOTNET_DLL_PATH@
+dotnet %~f0\dotnet\@DOTNET_DLL_PATH@ %*

--- a/cmake/Modules/dotnet/entry_point_with_cd.unix.in
+++ b/cmake/Modules/dotnet/entry_point_with_cd.unix.in
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P)"
+
+cd ${SCRIPTDIR}/dotnet/
+dotnet ${SCRIPTDIR}/dotnet/@DOTNET_DLL_PATH@ "$@"

--- a/cmake/Modules/dotnet/entry_point_with_cd.windows.in
+++ b/cmake/Modules/dotnet/entry_point_with_cd.windows.in
@@ -1,0 +1,2 @@
+cd /D %~f0\dotnet\
+dotnet %~f0\dotnet\@DOTNET_DLL_PATH@ %*


### PR DESCRIPTION
upstream PR for this internal one: https://github.com/schiller-de/dotnet_cmake_module/pull/1

Used to add build *.csproj files without generating them from cmake.

# New variants of `add_dotnet_*`

This PR adds the posibility to use your own `*.csproj` files instead of generating one with cmake.
This makes it easier to use advanced `*.csproj` features needed for ASP.NET as the developer can directly manipulate the `.csproj` file.

This is how the new commands corespond to the existing ones:
```
add_dotnet_executable -> add_dotnet_executable_project
add_dotnet_library -> add_dotnet_library_project
add_dotnet_test -> add_dotnet_test_project
```
Example:
```cmake
...
set(_assemblies_dep_dlls
    ${rcldotnet_common_ASSEMBLIES_DLL}
    ${rcldotnet_ASSEMBLIES_DLL}
    ${std_msgs_ASSEMBLIES_DLL}
    ${std_srvs_ASSEMBLIES_DLL}
)

add_dotnet_executable_project(RosBlazorExample
  PROJ
  src/RosBlazorExample/RosBlazorExample.csproj
  INCLUDE_DLLS
  ${_assemblies_dep_dlls}
)
...
```

RosBlazorExample.csproj needs to import a generated file for this to work:
```xml
  <Import Project="obj/CMake.g.props"/>
```